### PR TITLE
added zh_HK and zh_TW translations

### DIFF
--- a/translations/zh_HK.ts
+++ b/translations/zh_HK.ts
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK" sourcelanguage="zh_TW">
+<context>
+    <name>AppItem</name>
+    <message>
+        <location filename="../qml/AppItem.qml" line="50"/>
+        <source>Open</source>
+        <translation>開啟</translation>
+    </message>
+    <message>
+        <location filename="../qml/AppItem.qml" line="62"/>
+        <source>Unpin</source>
+        <translation>移除</translation>
+    </message>
+    <message>
+        <location filename="../qml/AppItem.qml" line="62"/>
+        <source>Pin</source>
+        <translation>固定</translation>
+    </message>
+    <message>
+        <location filename="../qml/AppItem.qml" line="69"/>
+        <source>Close All</source>
+        <translation>閂曬</translation>
+    </message>
+</context>
+<context>
+    <name>ControlCenter</name>
+    <message>
+        <location filename="../qml/ControlCenter.qml" line="167"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
+    </message>
+    <message>
+        <location filename="../qml/ControlCenter.qml" line="170"/>
+        <source>On</source>
+        <translation>開咗</translation>
+    </message>
+    <message>
+        <location filename="../qml/ControlCenter.qml" line="170"/>
+        <location filename="../qml/ControlCenter.qml" line="181"/>
+        <source>Off</source>
+        <translation>熄咗</translation>
+    </message>
+    <message>
+        <location filename="../qml/ControlCenter.qml" line="180"/>
+        <source>Bluetooth</source>
+        <translation>藍芽</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../qml/main.qml" line="125"/>
+        <source>Launcher</source>
+        <translation>程式啟動器</translation>
+    </message>
+</context>
+</TS>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>AppItem</name>
+    <message>
+        <location filename="../qml/AppItem.qml" line="50"/>
+        <source>Open</source>
+        <translation>開啟</translation>
+    </message>
+    <message>
+        <location filename="../qml/AppItem.qml" line="62"/>
+        <source>Unpin</source>
+        <translation>移除</translation>
+    </message>
+    <message>
+        <location filename="../qml/AppItem.qml" line="62"/>
+        <source>Pin</source>
+        <translation>固定</translation>
+    </message>
+    <message>
+        <location filename="../qml/AppItem.qml" line="69"/>
+        <source>Close All</source>
+        <translation>全部關閉</translation>
+    </message>
+</context>
+<context>
+    <name>ControlCenter</name>
+    <message>
+        <location filename="../qml/ControlCenter.qml" line="167"/>
+        <source>Wi-Fi</source>
+        <translation>Wi-Fi</translation>
+    </message>
+    <message>
+        <location filename="../qml/ControlCenter.qml" line="170"/>
+        <source>On</source>
+        <translation>開</translation>
+    </message>
+    <message>
+        <location filename="../qml/ControlCenter.qml" line="170"/>
+        <location filename="../qml/ControlCenter.qml" line="181"/>
+        <source>Off</source>
+        <translation>關</translation>
+    </message>
+    <message>
+        <location filename="../qml/ControlCenter.qml" line="180"/>
+        <source>Bluetooth</source>
+        <translation>藍芽</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../qml/main.qml" line="125"/>
+        <source>Launcher</source>
+        <translation>程式啟動器</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Warning: There's this [Chinese translations filename issue going on](https://github.com/cyberos/other-issues/issues/5#issuecomment-780259585). Using `zh_HK` as Cantonese and `zh_TW` as Chinese Traditional.

- Wi-Fi is not translated since everyone in TW and HK knows what it is and there's barely any accurate translations.
- `Unpin` is 移除, not sure if that is okay. We are having conflicts on this one. Not resolved.
- Considering `Program launcher` is more appropiate than `Application launcher`, using 程式啟動器.