### PR TITLE
藍芽 to 藍牙

### DIFF
--- a/translations/zh_HK.ts
+++ b/translations/zh_HK.ts
@@ -45,7 +45,7 @@
     <message>
         <location filename="../qml/ControlCenter.qml" line="180"/>
         <source>Bluetooth</source>
-        <translation>藍芽</translation>
+        <translation>藍牙</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -45,7 +45,7 @@
     <message>
         <location filename="../qml/ControlCenter.qml" line="180"/>
         <source>Bluetooth</source>
-        <translation>藍芽</translation>
+        <translation>藍牙</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
https://zh.wikipedia.org/zh-tw/%E8%97%8D%E7%89%99

> 「Bluetooth」一詞是斯堪地那維亞語言詞彙Blåtand/Blåtann的英語化。這個詞的來源是10世紀丹麥和挪威國王藍牙哈拉爾（丹麥語：Harald Blåtand Gormsen），借國王的綽號「Blåtand」當名稱，直接翻譯成中文爲「藍牙」（blå＝藍，tand＝牙）。原本台灣翻譯為「藍芽」，但2006年時，藍牙技術聯盟組織已將全球中文譯名統一改採直譯為「藍牙」，並註冊為該組織的註冊商標。[6]